### PR TITLE
make plugin compatible with php 5.3

### DIFF
--- a/core.php
+++ b/core.php
@@ -96,9 +96,7 @@ class RelativeDate {
       array_push($elements, array($this->difference->s, $this->language['sec']));
     }
 
-    return array_map(function($e) {
-      return $this->term($e);
-    }, $elements);
+    return array_map(array($this, 'term'), $elements);
   }
 
 


### PR DESCRIPTION
A closure using $this inside the array_map function is not compatible with php 5.3.
Since the minimum requirements for Kirby is php 5.3 I recommend using this notation.
I tested the change on a PHP 5.3 vagrant box.