### PR TITLE
prevent error when using relativedate on field without arguments

### DIFF
--- a/relative-date.php
+++ b/relative-date.php
@@ -56,6 +56,8 @@ field::$methods['relative'] = function($field, $args = null) {
       $args = array('lang' => $args);
     } elseif (is_int($args)) {
       $args = array('length' => $args);
+    } else {
+      $args = array();
     }
 
     $field->value = relativeDate($field->value, $args);


### PR DESCRIPTION
This prevents the error I get when using  `$item->published()->relative()` because the merge_array function in the relativeDate function expects an array and receives NULL.